### PR TITLE
precompile application on client-side

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ lib
 dist
 *.pyc
 *.pyo
+/play-*/
+/play-*.zip

--- a/conf/play-recipes.rb
+++ b/conf/play-recipes.rb
@@ -58,8 +58,11 @@ namespace :play do
   _cset :play_path do
     File.join(shared_path, "play-#{play_version}")
   end
-  _cset :play_cmd do
+  _cset :play_bin do
     File.join(play_path, 'play')
+  end
+  _cset :play_cmd do # override this if you want to set env vars (e.g. JAVA_HOME) for play
+    play_bin
   end
   _cset :play_daemonize_method, :play
   _cset :play_daemon do
@@ -76,8 +79,11 @@ namespace :play do
   _cset :play_path_local do
     File.join(".", "play-#{play_version}")
   end
-  _cset :play_cmd_local do
+  _cset :play_bin_local do
     File.join(play_path_local, 'play')
+  end
+  _cset :play_cmd_local do # override this if you want to set env vars (e.g. JAVA_HOME) for play
+    play_bin_local
   end
   _cset :play_precompile_locally, false # perform precompilation on localhost
 
@@ -133,12 +139,12 @@ namespace :play do
       run "#{try_sudo} rm -f #{play_zip_file}" unless play_preserve_zip
 
       run <<-E
-        if ! test -x #{play_cmd}; then
+        if ! test -x #{play_bin}; then
           ( test -f #{play_zip_file} ||
             ( wget --no-verbose -O #{temp_zip} #{play_zip_url} && #{try_sudo} mv -f #{temp_zip} #{play_zip_file}; true ) ) &&
           ( test -d #{play_path} ||
             ( unzip #{play_zip_file} -d #{File.dirname(temp_dir)} && #{try_sudo} mv -f #{temp_dir} #{play_path}; true ) ) &&
-          test -x #{play_cmd};
+          test -x #{play_bin};
         fi;
       E
       run "#{try_sudo} rm -f #{play_zip_file}" unless play_preserve_zip
@@ -150,11 +156,11 @@ namespace :play do
         logger.info(run_locally("rm -rf #{files.join(' ')}"))
       }
       logger.info(run_locally(<<-E))
-        if ! test -x #{play_cmd_local}; then
+        if ! test -x #{play_bin_local}; then
           ( test -f #{play_zip_file_local} ||
             ( wget --no-verbose -O #{play_zip_file_local} #{play_zip_url} ) ) &&
           ( test -d #{play_path_local} || unzip #{play_zip_file_local} -d #{File.dirname(play_path_local)} ) &&
-          test -x #{play_cmd_local};
+          test -x #{play_bin_local};
         fi;
       E
     end

--- a/conf/play-recipes.rb
+++ b/conf/play-recipes.rb
@@ -61,8 +61,12 @@ namespace :play do
   _cset :play_bin do
     File.join(play_path, 'play')
   end
-  _cset :play_cmd do # override this if you want to set env vars (e.g. JAVA_HOME) for play
-    play_bin
+  _cset :play_cmd do
+    if fetch(:play_java_home, nil)
+      "env JAVA_HOME=#{play_java_home} #{play_bin}"
+    else
+      play_bin
+    end
   end
   _cset :play_daemonize_method, :play
   _cset :play_daemon do
@@ -82,8 +86,12 @@ namespace :play do
   _cset :play_bin_local do
     File.join(play_path_local, 'play')
   end
-  _cset :play_cmd_local do # override this if you want to set env vars (e.g. JAVA_HOME) for play
-    play_bin_local
+  _cset :play_cmd_local do
+    if fetch(:play_java_home_local, nil)
+      "env JAVA_HOME=#{play_java_home_local} #{play_bin_local}"
+    else
+      play_bin_local
+    end
   end
   _cset :play_precompile_locally, false # perform precompilation on localhost
 

--- a/conf/play-recipes.rb
+++ b/conf/play-recipes.rb
@@ -138,6 +138,7 @@ namespace :play do
             ( wget --no-verbose -O #{temp_zip} #{play_zip_url} && #{try_sudo} mv -f #{temp_zip} #{play_zip_file}; true ) ) &&
           ( test -d #{play_path} ||
             ( unzip #{play_zip_file} -d #{File.dirname(temp_dir)} && #{try_sudo} mv -f #{temp_dir} #{play_path}; true ) ) &&
+          test -x #{play_cmd};
         fi;
       E
       run "#{try_sudo} rm -f #{play_zip_file}" unless play_preserve_zip
@@ -152,7 +153,8 @@ namespace :play do
         if ! test -x #{play_cmd_local}; then
           ( test -f #{play_zip_file_local} ||
             ( wget --no-verbose -O #{play_zip_file_local} #{play_zip_url} ) ) &&
-          ( test -d #{play_path_local} || unzip #{play_zip_file_local} -d #{File.dirname(play_path_local)} );
+          ( test -d #{play_path_local} || unzip #{play_zip_file_local} -d #{File.dirname(play_path_local)} ) &&
+          test -x #{play_cmd_local};
         fi;
       E
     end

--- a/conf/play-recipes.rb
+++ b/conf/play-recipes.rb
@@ -122,7 +122,10 @@ namespace :play do
       }
       template = File.read(play_ivy_settings_template)
       result = ERB.new(template).result(binding)
-      run "test -d #{File.dirname(play_ivy_settings)} || mkdir -p #{File.dirname(play_ivy_settings)}"
+      run <<-E
+        ( test -d #{File.dirname(play_ivy_settings)} || mkdir -p #{File.dirname(play_ivy_settings)} ) &&
+        ( test -f #{play_ivy_settings} && mv -f #{play_ivy_settings} #{play_ivy_settings}.orig; true );
+      E
       put result, tempfile
       run "diff #{play_ivy_settings} #{tempfile} || mv -f #{tempfile} #{play_ivy_settings}"
     end
@@ -131,8 +134,10 @@ namespace :play do
     task :setup_ivy_locally, :except => { :no_release => true } do
       template = File.read(play_ivy_settings_template)
       result = ERB.new(template).result(binding)
-      logger.info(run_locally("test -d #{File.dirname(play_ivy_settings_local)} || mkdir -p #{File.dirname(play_ivy_settings_local)}"))
-      logger.info(run_locally("test -f #{play_ivy_settings_local} && mv -f #{play_ivy_settings_local} #{play_ivy_settings_local}.orig"))
+      logger.info(run_locally(<<-E))
+        ( test -d #{File.dirname(play_ivy_settings_local)} || mkdir -p #{File.dirname(play_ivy_settings_local)} ) &&
+        ( test -f #{play_ivy_settings_local} && mv -f #{play_ivy_settings_local} #{play_ivy_settings_local}.orig; true );
+      E
       File.open(play_ivy_settings_local, 'w') { |fp| fp.write(result) }
     end
 

--- a/conf/play-recipes.rb
+++ b/conf/play-recipes.rb
@@ -78,10 +78,10 @@ namespace :play do
   _cset :play_use_precompile, true # performe precompilation before restarting service if true
 
   _cset :play_zip_file_local do
-    File.join(File.absolute_path('.'), 'tools', 'play', "play-#{play_version}.zip")
+    File.join(File.expand_path('.'), 'tools', 'play', "play-#{play_version}.zip")
   end
   _cset :play_path_local do
-    File.join(File.absolute_path('.'), 'tools', 'play', "play-#{play_version}")
+    File.join(File.expand_path('.'), 'tools', 'play', "play-#{play_version}")
   end
   _cset :play_bin_local do
     File.join(play_path_local, 'play')

--- a/conf/play-recipes.rb
+++ b/conf/play-recipes.rb
@@ -227,10 +227,10 @@ namespace :play do
   end
 
   task :dependencies_locally, :roles => :app, :except => { :no_release => true } do
-    run_locally "#{play_cmd_local} dependencies --forProd --sync"
+    logger.info(run_locally("#{play_cmd_local} dependencies --forProd --sync"))
     run "mkdir -p #{release_path}/lib #{release_path}/modules"
     find_servers_for_task(current_task).each { |server|
-      run_locally <<-E
+      logger.info(run_locally(<<-E))
         rsync -lrt --chmod=u+rwX,go+rX ./lib/ #{user}@#{server.host}:#{release_path}/lib/ &&
         rsync -lrt --chmod=u+rwX,go+rX ./modules/ #{user}@#{server.host}:#{release_path}/modules/;
       E
@@ -244,12 +244,12 @@ namespace :play do
 
   task :precompile_locally, :roles => :app, :except => { :no_release => true } do
     on_rollback {
-      run_locally "#{play_cmd_local} clean"
+      logger.info(run_locally("#{play_cmd_local} clean"))
     }
-    run_locally "#{play_cmd_local} precompile"
+    logger.info(run_locally("#{play_cmd_local} precompile"))
     run "mkdir -p #{release_path}/precompiled"
     find_servers_for_task(current_task).each { |server|
-      run_locally "rsync -lrt --chmod=u+rwX,go+rX ./precompiled/ #{user}@#{server.host}:#{release_path}/precompiled/"
+      logger.info(run_locally("rsync -lrt --chmod=u+rwX,go+rX ./precompiled/ #{user}@#{server.host}:#{release_path}/precompiled/"))
     }
     run "chmod -R g+w #{release_path}/precompiled" if fetch(:group_writable, true)
   end


### PR DESCRIPTION
I added "play:precompile_locally" task to run `play precompile` on client-side (deployer), not server-side (deployee).

This will result that the application pre-compilation will run just once if there are some servers.
And also, by the side effect, the total CPU consumption will be reduced during deployment.

The pre-compilation on client-side or server-side is managed by "play_precompile_locally" parameter, and disabled by default.
This is because SCM branch on client-side and server-side may be differ.
If using this feature, users should have care about SCM branch to deploy.
(We are configuring Jenkins to check out specified branch of our git repo.)
